### PR TITLE
:recycle: refactor sound end playback

### DIFF
--- a/include/core/services/Player.hpp
+++ b/include/core/services/Player.hpp
@@ -54,8 +54,8 @@ namespace core {
 
         std::atomic<bool> _shouldAdvanceToNext;
 
-        ma_uint64 _songStartTime;
-        bool _hasSongStartTime;
+        // ma_uint64 _songStartTime;
+        // bool _hasSongStartTime;
 
         /**
          * @brief Callback para quando uma música termina
@@ -72,6 +72,9 @@ namespace core {
          */
         void cleanupCurrentSound();
 
+        /**
+         * @brief Analisa flag para chamar playNextSong()
+         */
         void checkAndAdvanceIfNeeded();
 
     public:

--- a/include/core/services/Player.hpp
+++ b/include/core/services/Player.hpp
@@ -10,18 +10,22 @@
  */
 #pragma once
 
+#include <miniaudio.h>
+
+#include <memory>
+#include <vector>
+#include <atomic>
+
 #include "core/entities/Song.hpp"
 #include "core/services/PlaybackQueue.hpp"
-#include <atomic>
-#include <memory>
-#include <miniaudio.h>
-#include <vector>
 
 namespace core {
 
-    enum class PlayerState { STOPPED,
-                             PLAYING,
-                             PAUSED };
+    enum class PlayerState {
+        STOPPED,
+        PLAYING,
+        PAUSED
+    };
 
     /**
      * @class Player
@@ -34,8 +38,7 @@ namespace core {
     class Player {
     private:
         std::vector<std::shared_ptr<core::PlaybackQueue>> _queues;
-        std::shared_ptr<const core::Song>
-            _currentSong;
+        std::shared_ptr<const core::Song> _currentSong;
         int _currentQueueIndex;
         int _currentSongIndex;
         PlayerState _playerState;
@@ -49,14 +52,15 @@ namespace core {
         ma_sound _currentSound;
         bool _audioInitialized;
 
-        std::atomic<bool> _inCallback;
+        std::atomic<bool> _shouldAdvanceToNext;
+
         ma_uint64 _songStartTime;
         bool _hasSongStartTime;
 
         /**
          * @brief Callback para quando uma música termina
          */
-        static void sound_end_callback(void *pUserData, ma_sound *pSound);
+        static void onSoundEnd(void* pUserData, ma_sound* pSound);
 
         /**
          * @brief Carrega e prepara uma música para reprodução
@@ -67,6 +71,8 @@ namespace core {
          * @brief Limpa o som atual
          */
         void cleanupCurrentSound();
+
+        void checkAndAdvanceIfNeeded();
 
     public:
         /**
@@ -81,7 +87,7 @@ namespace core {
          * Inicializa o player com estado playing e volume máximo.
          * Deve criar o vetor de _queue com tracks no index 0
          */
-        Player(const core::PlaybackQueue &tracks);
+        Player(const core::PlaybackQueue& tracks);
 
         /**
          * @brief Destrutor
@@ -95,7 +101,7 @@ namespace core {
          * @brief Adicionar uma Queue ao vector _queue
          *
          */
-        void addPlaybackQueue(const core::PlaybackQueue &tracks);
+        void addPlaybackQueue(const core::PlaybackQueue& tracks);
 
         /**
          * @brief Reproduz música atual na Queue
@@ -255,6 +261,10 @@ namespace core {
          */
         int getPlaylistSize() const;
 
+        /*
+         * @brief Retorna a Queue do player
+         * @return Ponteiro de PlaybackQueue
+         */
         std::shared_ptr<PlaybackQueue> getPlaybackQueue() const;
 
         /**

--- a/src/cli/Cli.cpp
+++ b/src/cli/Cli.cpp
@@ -17,37 +17,37 @@
 #include <boost/filesystem.hpp>
 namespace fs = boost::filesystem;
 
-namespace cli
-{
-    std::string trimSpaces(const std::string &str)
-    {
+namespace cli {
+    std::string trimSpaces(const std::string& str) {
         size_t firstNonSpace = str.find_first_not_of(" \t\n\r\f\v");
 
-        if (firstNonSpace == std::string::npos)
-        {
+        if (firstNonSpace == std::string::npos) {
             return "";
         }
 
         return str.substr(firstNonSpace);
     }
 
-    Cli::Cli(core::ConfigManager &config_manager) : _config(config_manager)
-    {
+    Cli::Cli(core::ConfigManager& config_manager)
+        : _config(config_manager) {
         try {
             config_manager.loadConfig();
-        } catch (const std::exception &e) {
-            std::cerr << "Erro ao carregar o arquivo de configuração:\n\t" << e.what() << std::endl;
+        } catch (const std::exception& e) {
+            std::cerr << "Erro ao carregar o arquivo de configuração:\n\t"
+                      << e.what() << std::endl;
             throw;
         }
 
-        try
-        {
-            // _db = std::make_shared<SQLite::Database>(config_manager.databasePath(), SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE);
-            _db_manager = core::DatabaseManager(config_manager.databasePath(), config_manager.databaseSchemaPath());
-        }
-        catch (const std::exception &e)
-        {
-            std::cerr << "Erro ao conectar ao banco de dados: " << e.what() << std::endl;
+        try {
+            // _db =
+            // std::make_shared<SQLite::Database>(config_manager.databasePath(),
+            // SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE);
+            _db_manager =
+                core::DatabaseManager(config_manager.databasePath(),
+                                      config_manager.databaseSchemaPath());
+        } catch (const std::exception& e) {
+            std::cerr << "Erro ao conectar ao banco de dados: " << e.what()
+                      << std::endl;
             throw;
         }
 
@@ -56,15 +56,17 @@ namespace cli
 
         try {
             _user = _usersManager->getCurrentUser();
-        } catch (const std::exception &e) {
-            std::cerr << "Erro ao obter o usuário atual:\n\t" << e.what() << std::endl;
+        } catch (const std::exception& e) {
+            std::cerr << "Erro ao obter o usuário atual:\n\t" << e.what()
+                      << std::endl;
             throw;
         }
 
         try {
             _manager = std::make_shared<core::FilesManager>(config_manager);
-        } catch (const std::exception &e) {
-            std::cerr << "Erro ao criar o gerenciador principal:\n\t" << e.what() << std::endl;
+        } catch (const std::exception& e) {
+            std::cerr << "Erro ao criar o gerenciador principal:\n\t"
+                      << e.what() << std::endl;
             throw;
         }
 
@@ -78,57 +80,45 @@ namespace cli
         _db = _db_manager.getDatabase();
         _library = std::make_shared<core::Library>(_user, _db);
 
-
-        try
-        {
+        try {
             std::ifstream helpFile("../resources/help.json");
             helpFile >> _helpData;
-        }
-        catch (const std::exception &e)
-        {
-            std::cerr << "Erro ao carregar o arquivo de ajuda 'assets/help.json': " << e.what() << std::endl;
+        } catch (const std::exception& e) {
+            std::cerr
+                << "Erro ao carregar o arquivo de ajuda 'assets/help.json': "
+                << e.what() << std::endl;
         }
     }
 
-    void Cli::restart()
-    {
+    void Cli::restart() {
         _player->restart();
     }
 
-    void Cli::rewind(unsigned int seconds)
-    {
+    void Cli::rewind(unsigned int seconds) {
         _player->rewind(seconds);
     }
 
-    void Cli::forward(unsigned int seconds)
-    {
+    void Cli::forward(unsigned int seconds) {
         _player->fastForward(seconds);
     }
 
-    void Cli::toggleResumePause()
-    {
-        if (_player->isPlaying())
-        {
+    void Cli::toggleResumePause() {
+        if (_player->isPlaying()) {
             _player->pause();
-        }
-        else
-        {
+        } else {
             _player->resume();
         }
     }
 
-    void Cli::next()
-    {
+    void Cli::next() {
         _player->next();
     }
 
-    void Cli::previous()
-    {
+    void Cli::previous() {
         _player->previous();
     }
 
-    void Cli::setVolume(unsigned int volume)
-    {
+    void Cli::setVolume(unsigned int volume) {
         float vol = static_cast<float>(volume) / 100.0f;
         if (vol < 0.0f)
             vol = 0.0f;
@@ -137,85 +127,61 @@ namespace cli
         _player->setVolume(vol);
     }
 
-    void Cli::setVolumeUpDown(const std::string &volume)
-    {
-        if (volume == "up")
-        {
+    void Cli::setVolumeUpDown(const std::string& volume) {
+        if (volume == "up") {
             _player->setVolume(_player->getVolume() + volumeStep);
-        }
-        else if (volume == "down")
-        {
+        } else if (volume == "down") {
             _player->setVolume(_player->getVolume() - volumeStep);
         }
     }
 
-    void Cli::getVolume() const
-    {
+    void Cli::getVolume() const {
         float vol = _player->getVolume() * 100.0f;
-        std::cout << "Nivel de volume: " << static_cast<unsigned int>(vol) << std::endl;
+        std::cout << "Nivel de volume: " << static_cast<unsigned int>(vol)
+                  << std::endl;
     }
 
-    void Cli::toggleMute(const std::string &command)
-    {
-        if (command == "mute")
-        {
-
-            if (_player->isMuted())
-            {
+    void Cli::toggleMute(const std::string& command) {
+        if (command == "mute") {
+            if (_player->isMuted()) {
                 std::cout << "O player já está mudo." << std::endl;
                 return;
             }
 
             _player->mute();
-        }
-        else if (command == "unmute")
-        {
-            if (!_player->isMuted())
-            {
+        } else if (command == "unmute") {
+            if (!_player->isMuted()) {
                 std::cout << "O player não está no mudo." << std::endl;
                 return;
             }
 
             _player->unmute();
-        }
-        else if (command == "toggle_mute")
-        {
-            if (_player->isMuted())
-            {
+        } else if (command == "toggle_mute") {
+            if (_player->isMuted()) {
                 _player->unmute();
-            }
-            else
-            {
+            } else {
                 _player->mute();
             }
         }
     }
 
-    void Cli::getProgress() const
-    {
+    void Cli::getProgress() const {
         _player->getProgress();
     }
 
-    void Cli::clearQueue()
-    {
+    void Cli::clearQueue() {
         _player->clearPlaylist();
     }
 
-    void Cli::loop(const std::string &command)
-    {
-        if (command == "on")
-        {
-            if (_player->isLooping())
-            {
+    void Cli::loop(const std::string& command) {
+        if (command == "on") {
+            if (_player->isLooping()) {
                 std::cout << "O loop já está ativado." << std::endl;
                 return;
             }
             _player->setLooping();
-        }
-        else if (command == "off")
-        {
-            if (!_player->isLooping())
-            {
+        } else if (command == "off") {
+            if (!_player->isLooping()) {
                 std::cout << "O loop já está desativado." << std::endl;
                 return;
             }
@@ -223,88 +189,76 @@ namespace cli
         }
     }
 
-    void Cli::addToQueue(core::IPlayable &playabel)
-    {
-         std::cout << "queue adicionar 6" << std::endl;
-        try
-        {
+    void Cli::addToQueue(core::IPlayable& playabel) {
+        std::cout << "queue adicionar 6" << std::endl;
+        try {
             // core::RepositoryFactory repo_factory(_db);
 
-            // auto tracks = core::PlaybackQueue(_user, playabel, repo_factory.createHistoryPlaybackRepository());
+            // auto tracks = core::PlaybackQueue(_user, playabel,
+            // repo_factory.createHistoryPlaybackRepository());
             // _player->addPlaybackQueue(tracks);
             _player->getPlaybackQueue()->add(playabel);
             std::cout << "Adicionado à fila de reprodução." << std::endl;
-        }
-        catch (const std::exception &e)
-        {
-            std::cerr << "Erro ao adicionar à fila de reprodução: " << e.what() << std::endl;
+        } catch (const std::exception& e) {
+            std::cerr << "Erro ao adicionar à fila de reprodução: " << e.what()
+                      << std::endl;
         }
     }
 
-    void Cli::showQueue() const
-    {
+    void Cli::showQueue() const {
         auto queue = _player->getPlaybackQueue();
         // std::cout << "Fila de reprodução: \n"
         //           << queue->toString();
         std::cout << "Fila de reprodução detalhada: \n";
-        for (size_t i = 0; i < queue->size(); ++i)
-        {
+        for (size_t i = 0; i < queue->size(); ++i) {
             auto song = queue->at(i);
-            if (song)
-            {
-                std::cout << i + 1 << ". " << song->getTitle() << " - " << song->getArtist()->getName() << "\n";
+            if (song) {
+                std::cout << i + 1 << ". " << song->getTitle() << " - "
+                          << song->getArtist()->getName() << "\n";
             }
         }
     }
 
-    void Cli::like()
-    {
+    void Cli::like() {
         auto curtidas = _library->searchPlaylist("curtidas");
         auto queue = _player->getCurrentQueue();
         addToPlaylist(*curtidas[0], *queue->getCurrentSong());
     }
-    void Cli::deslike()
-    {
+    void Cli::deslike() {
         auto curtidas = _library->searchPlaylist("curtidas");
         auto queue = _player->getCurrentQueue();
         removeFromPlaylist(*curtidas[0], *queue->getCurrentSong());
     }
 
-    bool Cli::addToPlaylist(const core::IPlayable &playlist, const core::IPlayable &playabel)
-    {
+    bool Cli::addToPlaylist(const core::IPlayable& playlist,
+                            const core::IPlayable& playabel) {
         _library->addToPlaylist(playlist, playabel);
 
         return true;
     }
 
-    bool Cli::removeFromPlaylist(const core::IPlayable &playlist, const core::IPlayable &playabel)
-    {
+    bool Cli::removeFromPlaylist(const core::IPlayable& playlist,
+                                 const core::IPlayable& playabel) {
         _library->removeFromPlaylist(playlist, playabel);
         return true;
     }
 
-    void Cli::play()
-    {
-        if (_player->getPlaybackQueue()){
+    void Cli::play() {
+        if (_player->getPlaybackQueue()) {
             _player->play();
-    }
+        }
     }
 
-    void Cli::shuffle()
-    {
+    void Cli::shuffle() {
         _player->getPlaybackQueue()->shuffle();
     }
 
-    void Cli::removeFromQueue(unsigned idx)
-    {
+    void Cli::removeFromQueue(unsigned idx) {
         _player->getPlaybackQueue()->remove(idx);
     }
 
-    void Cli::showStatus() const
-    {
-        try
-        {
-
+    void Cli::showStatus() const {
+        try {
             std::cout << "=== Player Status ===" << std::endl;
 
             std::string state;
@@ -323,20 +277,18 @@ namespace cli
                 std::cout << " (muted)";
             std::cout << std::endl;
 
-            std::cout << "Loop: " << (_player->isLooping() ? "on" : "off") << std::endl;
+            std::cout << "Loop: " << (_player->isLooping() ? "on" : "off")
+                      << std::endl;
 
             std::shared_ptr<core::PlaybackQueue> queue;
 
             queue = _player->getPlaybackQueue();
 
-            if (queue)
-            {
+            if (queue) {
                 std::cout << "Tamanho da fila: " << queue->size() << std::endl;
 
                 auto curr = queue->getCurrentSong();
-                if (curr)
-                {
-
+                if (curr) {
                     std::cout << "Musica atual: " << curr->getTitle();
                     if (curr->getArtist())
                         std::cout << " - " << curr->getArtist()->getName();
@@ -349,65 +301,75 @@ namespace cli
 
                     progress = _player->getProgress();
 
-                    if (progress > 0.0f && elapsed > 0)
-                    {
-                        unsigned int total = static_cast<unsigned int>(elapsed / progress);
+                    if (progress > 0.0f && elapsed > 0) {
+                        // unsigned int total = static_cast<unsigned
+                        // int>(elapsed / progress); unsigned int m = elapsed /
+                        // 60; unsigned int sec = elapsed % 60; char
+                        // bufElapsed[32]; std::snprintf(bufElapsed,
+                        // sizeof(bufElapsed), "%02u:%02u", m, sec); m = total /
+                        // 60; sec = total % 60; char bufTotal[32];
+                        // std::snprintf(bufTotal, sizeof(bufTotal),
+                        // "%02u:%02u", m, sec);
 
-                        unsigned int m = elapsed / 60;
-                        unsigned int sec = elapsed % 60;
-                        char bufElapsed[32];
-                        std::snprintf(bufElapsed, sizeof(bufElapsed), "%02u:%02u", m, sec);
+                        int totalSeconds = elapsed;
+                        int h = totalSeconds / 3600;
+                        int m = (totalSeconds % 3600) / 60;
+                        int s = totalSeconds % 60;
 
-                        m = total / 60;
-                        sec = total % 60;
-                        char bufTotal[32];
-                        std::snprintf(bufTotal, sizeof(bufTotal), "%02u:%02u", m, sec);
+                        std::string formatted;
+                        if (h > 0) {
+                            formatted =
+                                std::to_string(h) + ":" + (m < 10 ? "0" : "")
+                                + std::to_string(m) + ":" + (s < 10 ? "0" : "")
+                                + std::to_string(s);
+                        } else {
+                            formatted = std::to_string(m) + ":"
+                                        + (s < 10 ? "0" : "")
+                                        + std::to_string(s);
+                        }
 
-                        std::cout << "Progresso: " << bufElapsed << " / " << bufTotal << std::endl;
-                    }
-                    else
-                    {
+                        auto totalDuration = _player->getPlaybackQueue()
+                                                 ->getCurrentSong()
+                                                 ->getFormattedDuration();
+
+                        std::cout << "Progresso: " << formatted << " / "
+                                  << totalDuration << std::endl;
+                    } else {
                         std::cout << "Progresso: 0:0/0:0" << std::endl;
                     }
-                }
-                else
-                {
-                    std::cout << "Nenhuma musica carregada atualmente." << std::endl;
+                } else {
+                    std::cout << "Nenhuma musica carregada atualmente."
+                              << std::endl;
                 }
 
                 auto next = queue->getNextSong();
-                if (next)
-                {
-
+                if (next) {
                     std::cout << "Proxima musica: " << next->getTitle();
                     if (next->getArtist())
                         std::cout << " - " << next->getArtist()->getName();
                     std::cout << std::endl;
-                }
-                else
-                {
+                } else {
                     std::cout << "Proxima musica: (nenhuma)" << std::endl;
                 }
-            }
-            else
-            {
+            } else {
                 std::cout << "Fila: N/D" << std::endl;
             }
 
             std::cout << "======================" << std::endl;
-        }
-        catch (const std::exception &e)
-        {
-            std::cerr << "Erro ao obter status do player: " << e.what() << std::endl;
+        } catch (const std::exception& e) {
+            std::cerr << "Erro ao obter status do player: " << e.what()
+                      << std::endl;
         }
     }
 
     void Cli::updateUsers() {
         try {
             _usersManager->updateUsersList();
-            std::cout << "Lista de usuários atualizada com sucesso." << std::endl;
-        } catch (const std::exception &e) {
-            std::cerr << "Erro ao atualizar a lista de usuários: " << e.what() << std::endl;
+            std::cout << "Lista de usuários atualizada com sucesso."
+                      << std::endl;
+        } catch (const std::exception& e) {
+            std::cerr << "Erro ao atualizar a lista de usuários: " << e.what()
+                      << std::endl;
         }
     }
 
@@ -415,578 +377,498 @@ namespace cli
         try {
             _manager->update();
             std::cout << "Biblioteca atualizada com sucesso." << std::endl;
-        } catch (const std::exception &e) {
-            std::cerr << "Erro ao atualizar a biblioteca: " << e.what() << std::endl;
+        } catch (const std::exception& e) {
+            std::cerr << "Erro ao atualizar a biblioteca: " << e.what()
+                      << std::endl;
         }
     }
 
-    void Cli::showHelp() const
-    {
-        if (_helpData.empty() || !_helpData.contains("commands"))
-        {
+    void Cli::showHelp() const {
+        if (_helpData.empty() || !_helpData.contains("commands")) {
             std::cout << "Nenhuma informação de ajuda disponível." << std::endl;
             return;
         }
 
         std::cout << "Comandos disponíveis:" << std::endl;
-        for (auto it = _helpData["commands"].begin(); it != _helpData["commands"].end(); ++it)
-        {
+        for (auto it = _helpData["commands"].begin();
+             it != _helpData["commands"].end();
+             ++it) {
             std::cout << "  " << std::left << std::setw(15) << it.key()
                       << it.value().value("description", "") << std::endl;
         }
-        std::cout << "\nDigite 'help <comando>' para mais detalhes." << std::endl;
+        std::cout << "\nDigite 'help <comando>' para mais detalhes."
+                  << std::endl;
     }
 
-    void Cli::showHelp(const std::string &topic) const
-    {
-        if (topic.empty())
-        {
+    void Cli::showHelp(const std::string& topic) const {
+        if (topic.empty()) {
             showHelp();
             return;
         }
 
-        if (_helpData.empty() || !_helpData.contains("commands") || !_helpData["commands"].contains(topic))
-        {
-            std::cout << "Nenhuma ajuda encontrada para o comando '" << topic << "'." << std::endl;
+        if (_helpData.empty() || !_helpData.contains("commands")
+            || !_helpData["commands"].contains(topic)) {
+            std::cout << "Nenhuma ajuda encontrada para o comando '" << topic
+                      << "'." << std::endl;
             return;
         }
 
-        const auto &cmd_info = _helpData["commands"][topic];
+        const auto& cmd_info = _helpData["commands"][topic];
         std::cout << "Ajuda para o comando: " << topic << std::endl;
-        std::cout << "  Descrição: " << cmd_info.value("description", "N/A") << std::endl;
+        std::cout << "  Descrição: " << cmd_info.value("description", "N/A")
+                  << std::endl;
         std::cout << "  Uso: " << cmd_info.value("usage", "N/A") << std::endl;
-        if (cmd_info.contains("aliases"))
-        {
-            std::cout << "  Apelidos: " << cmd_info["aliases"].dump() << std::endl;
+        if (cmd_info.contains("aliases")) {
+            std::cout << "  Apelidos: " << cmd_info["aliases"].dump()
+                      << std::endl;
         }
     }
 
-    void Cli::searchSong(const std::string &query) const
-    {
+    void Cli::searchSong(const std::string& query) const {
         auto songs = _library->searchSong(query);
-        std::cout << "Procurando por músicas com o termo: " << query << std::endl;
-        if (songs.empty())
-        {
-            std::cout << "Nenhuma música encontrada para: " << query << std::endl;
+        std::cout << "Procurando por músicas com o termo: " << query
+                  << std::endl;
+        if (songs.empty()) {
+            std::cout << "Nenhuma música encontrada para: " << query
+                      << std::endl;
             return;
-        }
-        else if (songs.size() == 1)
-        {
-            std::cout << "1 música encontrada: " << songs.at(0)->getTitle() << std::endl;
-        }
-        else
-        {
+        } else if (songs.size() == 1) {
+            std::cout << "1 música encontrada: " << songs.at(0)->getTitle()
+                      << std::endl;
+        } else {
             std::cout << songs.size() << "Músicas encontradas: \n";
             for (auto song : songs)
                 std::cout << song->getTitle() << std::endl;
         }
     }
 
-    void Cli::searchArtist(const std::string &query) const
-    {
+    void Cli::searchArtist(const std::string& query) const {
         auto artists = _library->searchArtist(query);
-        if (artists.empty())
-        {
-            std::cout << "Nenhum artista encontrado para:" << query << std::endl;
+        if (artists.empty()) {
+            std::cout << "Nenhum artista encontrado para:" << query
+                      << std::endl;
             return;
-        }
-        else if (artists.size() == 1)
-        {
-            std::cout << "1 artista encontrado: " << artists.at(0)->getName() << std::endl;
-        }
-        else
-        {
+        } else if (artists.size() == 1) {
+            std::cout << "1 artista encontrado: " << artists.at(0)->getName()
+                      << std::endl;
+        } else {
             std::cout << artists.size() << "Artistas encontrados: \n";
             for (auto artist : artists)
                 std::cout << artist->getName() << std::endl;
         }
     }
 
-    void Cli::searchAlbum(const std::string &query) const
-    {
+    void Cli::searchAlbum(const std::string& query) const {
         auto albums = _library->searchAlbum(query);
-        if (albums.empty())
-        {
+        if (albums.empty()) {
             std::cout << "Nenhum album encontrado para: " << query << std::endl;
             return;
-        }
-        else if (albums.size() == 1)
-        {
-            std::cout << "1 album encontrado: " << albums.at(0)->getName() << std::endl;
-        }
-        else
-        {
+        } else if (albums.size() == 1) {
+            std::cout << "1 album encontrado: " << albums.at(0)->getName()
+                      << std::endl;
+        } else {
             std::cout << albums.size() << "Albuns encontrados: \n";
             for (auto album : albums)
-                std::cout << album->getName() << " por " << album->getArtist()->getName() << std::endl;
+                std::cout << album->getName() << " por "
+                          << album->getArtist()->getName() << std::endl;
         }
     }
 
-    void Cli::searchPlaylist(const std::string &query) const
-    {
+    void Cli::searchPlaylist(const std::string& query) const {
         auto playlists = _library->searchPlaylist(query);
-        if (playlists.empty())
-        {
-            std::cout << "Nenhuma playlist encontrada para: " << query << std::endl;
+        if (playlists.empty()) {
+            std::cout << "Nenhuma playlist encontrada para: " << query
+                      << std::endl;
             return;
-        }
-        else if (playlists.size() == 1)
-        {
-            std::cout << "1 playlist encontrada: " << playlists.at(0)->getTitle() << std::endl;
-        }
-        else
-        {
+        } else if (playlists.size() == 1) {
+            std::cout << "1 playlist encontrada: "
+                      << playlists.at(0)->getTitle() << std::endl;
+        } else {
             std::cout << playlists.size() << "Playlists encontradas: \n";
             for (auto playlist : playlists)
                 std::cout << playlist->getTitle() << std::endl;
         }
     }
 
-    void Cli::showPlaylist(core::IPlayable &playlist) const
-    {
-        auto pl = dynamic_cast<core::Playlist *>(&playlist);
-        if (pl)
-        {
+    void Cli::showPlaylist(core::IPlayable& playlist) const {
+        auto pl = dynamic_cast<core::Playlist*>(&playlist);
+        if (pl) {
             std::cout << "Playlist: " << pl->getTitle() << std::endl;
             auto songs = pl->getSongs();
-            for (const auto &song : songs)
-            {
+            for (const auto& song : songs) {
                 std::cout << "- " << song->getTitle() << std::endl;
             }
-        }
-        else
-        {
-            std::cout << "O objeto fornecido não é uma playlist válida." << std::endl;
+        } else {
+            std::cout << "O objeto fornecido não é uma playlist válida."
+                      << std::endl;
         }
     }
 
-    void Cli::showAlbum(core::IPlayable &album) const
-    {
-        auto al = dynamic_cast<core::Album *>(&album);
-        if (al)
-        {
+    void Cli::showAlbum(core::IPlayable& album) const {
+        auto al = dynamic_cast<core::Album*>(&album);
+        if (al) {
             al->toString();
-        }
-        else
-        {
-            std::cout << "O objeto fornecido não é uma playlist válida." << std::endl;
+        } else {
+            std::cout << "O objeto fornecido não é uma playlist válida."
+                      << std::endl;
         }
     }
 
-    void Cli::showArtist(core::IPlayable &artist) const
-    {
-        auto ar = dynamic_cast<core::Artist *>(&artist);
-        if (ar)
-        {
+    void Cli::showArtist(core::IPlayable& artist) const {
+        auto ar = dynamic_cast<core::Artist*>(&artist);
+        if (ar) {
             ar->toString();
-        }
-        else
-        {
-            std::cout << "O objeto fornecido não é uma playlist válida." << std::endl;
+        } else {
+            std::cout << "O objeto fornecido não é uma playlist válida."
+                      << std::endl;
         }
     }
 
-    void Cli::start()
-    {
+    void Cli::start() {
         std::string command;
         std::cout << "Bem-vindo ao frankenstein Music Player!" << std::endl;
-        std::cout << "Digite 'help' para ver a lista de comandos disponíveis." << std::endl;
+        std::cout << "Digite 'help' para ver a lista de comandos disponíveis."
+                  << std::endl;
 
-        while (true)
-        {
+        while (true) {
             std::cout << "frankenstein> ";
             std::getline(std::cin, command);
 
-            if (command == "exit" || command == "quit")
-            {
-                std::cout << "Saindo do frankenstein Music Player. Até logo!" << std::endl;
+            if (command == "exit" || command == "quit") {
+                std::cout << "Saindo do frankenstein Music Player. Até logo!"
+                          << std::endl;
                 break;
             }
 
             bool success = doCommand(command);
-            if (!success)
-            {
+            if (!success) {
                 std::cout << "Digite um comando valido!" << std::endl;
             }
         }
     }
 
-    bool Cli::doCommand(const std::string &command)
-    {
+    bool Cli::doCommand(const std::string& command) {
         std::stringstream ss(command);
 
         std::string firstCommand;
         ss >> firstCommand;
 
         try {
-        if (firstCommand.empty())
-        {
-            std::cout << "Comando vazio. Por favor, insira um comando válido." << std::endl;
-            return false;
-        }
-        else if (firstCommand == "info" || firstCommand == "status")
-        {
-            showStatus();
-            return true;
-        }
-        else if (firstCommand == "play" || firstCommand == "pause" || firstCommand == "resume")
-        {
-            if (firstCommand == "play")
-            {
+            if (firstCommand.empty()) {
+                std::cout
+                    << "Comando vazio. Por favor, insira um comando válido."
+                    << std::endl;
+                return false;
+            } else if (firstCommand == "info" || firstCommand == "status") {
+                showStatus();
+                return true;
+            } else if (firstCommand == "play" || firstCommand == "pause"
+                       || firstCommand == "resume") {
+                if (firstCommand == "play") {
+                    _player->play();
+                    return true;
+                }
 
-                _player->play();
+                toggleResumePause();
+                return true;
+            } else if (firstCommand == "replay" || firstCommand == "restart") {
+                restart();
                 return true;
             }
 
-            toggleResumePause();
-            return true;
-        }
-        else if (firstCommand == "replay" || firstCommand == "restart")
-        {
-            restart();
-            return true;
-        }
-
-        else if (firstCommand == "volume")
-        {
-            std::string volumeCommand;
-            if (ss >> volumeCommand)
-            {
-                if (volumeCommand == "up" || volumeCommand == "down")
-                {
-                    setVolumeUpDown(volumeCommand);
-                    return true;
-                }
-                else if (volumeCommand == "set")
-                {
-                    unsigned int num;
-                    if (ss >> num)
-                    {
-                        setVolume(num);
+            else if (firstCommand == "volume") {
+                std::string volumeCommand;
+                if (ss >> volumeCommand) {
+                    if (volumeCommand == "up" || volumeCommand == "down") {
+                        setVolumeUpDown(volumeCommand);
                         return true;
-                    }
-                }
-                std::cout << "Comando inválido para volume. Use 'volume up', 'volume down' ou 'volume set <value>'." << std::endl;
-                return false;
-            }
-
-            getVolume();
-            return true;
-        }
-        else if (firstCommand == "rewind")
-        {
-            unsigned int seconds;
-            if (ss >> seconds)
-            {
-                rewind(seconds);
-                return true;
-            }
-            else
-            {
-                std::cout << "Por favor, forneça o número de segundos para retroceder." << std::endl;
-                return false;
-            }
-        }
-        else if (firstCommand == "forward")
-        {
-            unsigned int seconds;
-            if (ss >> seconds)
-            {
-                forward(seconds);
-                return true;
-            }
-
-            std::cout << "Por favor, forneça o número de segundos para avançar." << std::endl;
-            return false;
-        }
-        else if (firstCommand == "mute" || firstCommand == "unmute" || firstCommand == "toggle_mute")
-        {
-            toggleMute(firstCommand);
-            return true;
-        }
-        else if (firstCommand == "next")
-        {
-            next();
-            return true;
-        }
-        else if (firstCommand == "previous")
-        {
-            previous();
-            return true;
-        }
-        else if (firstCommand == "like")
-        {
-            like();
-            return true;
-        }
-        else if (firstCommand == "deslike")
-        {
-            deslike();
-            return true;
-        }
-        else if (firstCommand == "shuffle")
-        {
-            shuffle();
-            return true;
-        }
-        else if (firstCommand == "loop")
-        {
-            std::string loopCommand;
-            if (ss >> loopCommand)
-            {
-                if (loopCommand == "on" || loopCommand == "off")
-                {
-                    loop(loopCommand);
-                    return true;
-                }
-                else
-                {
-                    std::cout << "Comando inválido para loop. Use 'loop on' ou 'loop off'." << std::endl;
-
-                    return false;
-                }
-            }
-            showHelp("loop");
-            return true;
-        }
-        else if (firstCommand == "queue")
-        {
-            std::string queueCommand;
-
-            if (ss >> queueCommand)
-            {
-                if (queueCommand == "clear")
-                {
-                    clearQueue();
-                    return true;
-                }
-                else if (queueCommand == "show")
-                {
-                    showQueue();
-                    return true;
-                }
-                else if (queueCommand == "add")
-                {
-                    std::string playable;
-                    std::getline(ss, playable);
-                    playable = trimSpaces(playable);
-                    if (!playable.empty())
-                    {
-                        auto opt = _library->searchSong(playable);
-                        if (opt.empty())
-                        {
-                            std::cout << "Música não encontrada: " << playable << std::endl;
-                            return false;
+                    } else if (volumeCommand == "set") {
+                        unsigned int num;
+                        if (ss >> num) {
+                            setVolume(num);
+                            return true;
                         }
-
-                        auto sp = opt.at(0);
-                        addToQueue(*sp);
-                        return true;
                     }
-
-                    std::cout << "Por favor, forneça o nome da música para adicionar à fila." << std::endl;
+                    std::cout << "Comando inválido para volume. Use 'volume "
+                                 "up', 'volume down' ou 'volume set <value>'."
+                              << std::endl;
                     return false;
                 }
-                else if (queueCommand == "remove")
-                {
-                    unsigned idx;
-                    if (ss >> idx)
-                    {
-                        removeFromQueue(idx);
+
+                getVolume();
+                return true;
+            } else if (firstCommand == "rewind") {
+                unsigned int seconds;
+                if (ss >> seconds) {
+                    rewind(seconds);
+                    return true;
+                } else {
+                    std::cout << "Por favor, forneça o número de segundos para "
+                                 "retroceder."
+                              << std::endl;
+                    return false;
+                }
+            } else if (firstCommand == "forward") {
+                unsigned int seconds;
+                if (ss >> seconds) {
+                    forward(seconds);
+                    return true;
+                }
+
+                std::cout
+                    << "Por favor, forneça o número de segundos para avançar."
+                    << std::endl;
+                return false;
+            } else if (firstCommand == "mute" || firstCommand == "unmute"
+                       || firstCommand == "toggle_mute") {
+                toggleMute(firstCommand);
+                return true;
+            } else if (firstCommand == "next") {
+                next();
+                return true;
+            } else if (firstCommand == "previous") {
+                previous();
+                return true;
+            } else if (firstCommand == "like") {
+                like();
+                return true;
+            } else if (firstCommand == "deslike") {
+                deslike();
+                return true;
+            } else if (firstCommand == "shuffle") {
+                shuffle();
+                return true;
+            } else if (firstCommand == "loop") {
+                std::string loopCommand;
+                if (ss >> loopCommand) {
+                    if (loopCommand == "on" || loopCommand == "off") {
+                        loop(loopCommand);
                         return true;
-                    }
-                    else
-                    {
-                        std::cout << "Por favor, forneça o índice da música para remover da fila." << std::endl;
+                    } else {
+                        std::cout << "Comando inválido para loop. Use 'loop "
+                                     "on' ou 'loop off'."
+                                  << std::endl;
+
                         return false;
                     }
                 }
-                else
-                {
-                    std::cout << "Comando inválido para queue. Use 'queue show', 'queue clear', 'queue add <song>' ou 'queue remove <index>'." << std::endl;
-                    return false;
-                }
-            }
+                showHelp("loop");
+                return true;
+            } else if (firstCommand == "queue") {
+                std::string queueCommand;
 
-            showHelp("queue");
-            return true;
-        }
-        else if (firstCommand == "playlist")
-        {
-            std::string playlistCommand;
+                if (ss >> queueCommand) {
+                    if (queueCommand == "clear") {
+                        clearQueue();
+                        return true;
+                    } else if (queueCommand == "show") {
+                        showQueue();
+                        return true;
+                    } else if (queueCommand == "add") {
+                        std::string playable;
+                        std::getline(ss, playable);
+                        playable = trimSpaces(playable);
+                        if (!playable.empty()) {
+                            auto opt = _library->searchSong(playable);
+                            if (opt.empty()) {
+                                std::cout
+                                    << "Música não encontrada: " << playable
+                                    << std::endl;
+                                return false;
+                            }
 
-            if (ss >> playlistCommand)
-            {
-                if (playlistCommand == "show")
-                {
-                    std::string playlist;
-                    std::getline(ss, playlist);
-                    playlist = trimSpaces(playlist);
-                    if (!playlist.empty())
-                    {
-                        auto optPl = _library->searchPlaylist(playlist);
-                        if (optPl.empty())
-                        {
-                            std::cout << "Playlist não encontrada: " << playlist << std::endl;
+                            auto sp = opt.at(0);
+                            addToQueue(*sp);
+                            return true;
+                        }
+
+                        std::cout << "Por favor, forneça o nome da música para "
+                                     "adicionar à fila."
+                                  << std::endl;
+                        return false;
+                    } else if (queueCommand == "remove") {
+                        unsigned idx;
+                        if (ss >> idx) {
+                            removeFromQueue(idx);
+                            return true;
+                        } else {
+                            std::cout << "Por favor, forneça o índice da "
+                                         "música para remover da fila."
+                                      << std::endl;
                             return false;
                         }
-                        auto spPl = optPl.at(0);
-                        showPlaylist(*spPl);
-                        return true;
+                    } else {
+                        std::cout << "Comando inválido para queue. Use 'queue "
+                                     "show', 'queue clear', 'queue add <song>' "
+                                     "ou 'queue remove <index>'."
+                                  << std::endl;
+                        return false;
                     }
-                    std::cout << "Por favor, forneça o nome da playlist que deseja ver." << std::endl;
-                    showHelp("playlist");
-                    return true;
                 }
-                else if (playlistCommand == "add")
-                {
-                    std::string playlist;
 
-                    // mudar para std::getline(ss, playlist);
-                    if (ss >> playlist)
-                    {
-                        std::string playable;
-                        std::getline(ss, playable);
-                        playable = trimSpaces(playable);
-                        if (!playable.empty())
-                        {
+                showHelp("queue");
+                return true;
+            } else if (firstCommand == "playlist") {
+                std::string playlistCommand;
+
+                if (ss >> playlistCommand) {
+                    if (playlistCommand == "show") {
+                        std::string playlist;
+                        std::getline(ss, playlist);
+                        playlist = trimSpaces(playlist);
+                        if (!playlist.empty()) {
                             auto optPl = _library->searchPlaylist(playlist);
-                            if (optPl.empty())
-                            {
-                                std::cout << "Playlist não encontrada: " << playlist << std::endl;
-                                return false;
-                            }
-                            auto optSong = _library->searchSong(playable);
-                            if (optSong.empty())
-                            {
-                                std::cout << "Musica não encontrada: " << playable << std::endl;
+                            if (optPl.empty()) {
+                                std::cout
+                                    << "Playlist não encontrada: " << playlist
+                                    << std::endl;
                                 return false;
                             }
                             auto spPl = optPl.at(0);
-                            auto spSong = optSong.at(0);
-                            addToPlaylist(*spPl, *spSong);
+                            showPlaylist(*spPl);
+                            return true;
+                        }
+                        std::cout << "Por favor, forneça o nome da playlist "
+                                     "que deseja ver."
+                                  << std::endl;
+                        showHelp("playlist");
+                        return true;
+                    } else if (playlistCommand == "add") {
+                        std::string playlist;
+
+                        // mudar para std::getline(ss, playlist);
+                        if (ss >> playlist) {
+                            std::string playable;
+                            std::getline(ss, playable);
+                            playable = trimSpaces(playable);
+                            if (!playable.empty()) {
+                                auto optPl = _library->searchPlaylist(playlist);
+                                if (optPl.empty()) {
+                                    std::cout << "Playlist não encontrada: "
+                                              << playlist << std::endl;
+                                    return false;
+                                }
+                                auto optSong = _library->searchSong(playable);
+                                if (optSong.empty()) {
+                                    std::cout
+                                        << "Musica não encontrada: " << playable
+                                        << std::endl;
+                                    return false;
+                                }
+                                auto spPl = optPl.at(0);
+                                auto spSong = optSong.at(0);
+                                addToPlaylist(*spPl, *spSong);
+                                return true;
+                            }
+
+                            std::cout << "Por favor, forneça o nome da música "
+                                         "para adicionar à playlist."
+                                      << std::endl;
+                            showHelp("playlist");
+                            return true;
+                        }
+                        std::cout << "Por favor, forneça o nome da da playlist "
+                                     "e nome da musica a ser adicionada."
+                                  << std::endl;
+                        showHelp("playlist");
+                        return true;
+                    } else if (playlistCommand == "remove") {
+                        std::string playlist;
+
+                        // mudar para std::getline(ss, playlist);
+                        if (ss >> playlist) {
+                            std::string playable;
+                            std::getline(ss, playable);
+                            playable = trimSpaces(playable);
+                            if (!playable.empty()) {
+                                auto optPl = _library->searchPlaylist(playlist);
+                                if (optPl.empty()) {
+                                    std::cout << "Playlist não encontrada: "
+                                              << playlist << std::endl;
+                                    return false;
+                                }
+
+                                auto optSong = _library->searchSong(playable);
+                                if (optSong.empty()) {
+                                    std::cout
+                                        << "Música não encontrada: " << playable
+                                        << std::endl;
+                                    return false;
+                                }
+
+                                auto spPl = optPl.at(0);
+                                auto spSong = optSong.at(0);
+                                removeFromPlaylist(*spPl, *spSong);
+                                return true;
+                            }
+
+                            std::cout << "Por favor, forneça o nome da música "
+                                         "para remover da playlist."
+                                      << std::endl;
+                            showHelp("playlist");
                             return true;
                         }
 
-                        std::cout << "Por favor, forneça o nome da música para adicionar à playlist." << std::endl;
-                        showHelp("playlist");
-                        return true;
-                    }
-                    std::cout << "Por favor, forneça o nome da da playlist e nome da musica a ser adicionada." << std::endl;
-                    showHelp("playlist");
-                    return true;
-                }
-                else if (playlistCommand == "remove")
-                {
-                    std::string playlist;
-
-                    // mudar para std::getline(ss, playlist);
-                    if (ss >> playlist)
-                    {
-                        std::string playable;
-                        std::getline(ss, playable);
-                        playable = trimSpaces(playable);
-                        if (!playable.empty())
-                        {
-
-                            auto optPl = _library->searchPlaylist(playlist);
-                            if (optPl.empty())
-                            {
-                                std::cout << "Playlist não encontrada: " << playlist << std::endl;
-                                return false;
-                            }
-
-                            auto optSong = _library->searchSong(playable);
-                            if (optSong.empty())
-                            {
-                                std::cout << "Música não encontrada: " << playable << std::endl;
-                                return false;
-                            }
-
-                            auto spPl = optPl.at(0);
-                            auto spSong = optSong.at(0);
-                            removeFromPlaylist(*spPl, *spSong);
-                            return true;
-                        }
-
-                        std::cout << "Por favor, forneça o nome da música para remover da playlist." << std::endl;
+                        std::cout << "Por favor, forneça o nome da playlist e "
+                                     "nome da musica a ser removida."
+                                  << std::endl;
                         showHelp("playlist");
                         return true;
                     }
 
-                    std::cout << "Por favor, forneça o nome da playlist e nome da musica a ser removida." << std::endl;
-                    showHelp("playlist");
-                    return true;
+                    std::cout << "Comando inválido para playlist." << std::endl;
                 }
 
-                std::cout << "Comando inválido para playlist." << std::endl;
+                showHelp("playlist");
+                return true;
+            } else if (firstCommand == "update_users") {
+                updateUsers();
+                return true;
+            } else if (firstCommand == "update_songs"
+                       || firstCommand == "update_library") {
+                updateSongs();
+                return true;
+            } else if (firstCommand == "search") {
+                std::string searchType;
+                if (ss >> searchType) {
+                    std::string query;
+                    std::getline(ss, query);
+                    query.erase(0, query.find_first_not_of(" "));
+
+                    if (searchType == "music" || searchType == "song") {
+                        searchSong(query);
+                        return true;
+                    } else if (searchType == "artist") {
+                        searchArtist(query);
+                        return true;
+                    } else if (searchType == "album") {
+                        searchAlbum(query);
+                        return true;
+                    } else if (searchType == "playlist") {
+                        searchPlaylist(query);
+                        return true;
+                    } else {
+                        std::cout << "Tipo de busca inválido. Use 'music', "
+                                     "'artist', 'album' ou 'playlist'."
+                                  << std::endl;
+                        return false;
+                    }
+                }
+
+                showHelp("search");
+                return true;
+            } else if (firstCommand == "help") {
+                ss >> firstCommand ? showHelp(firstCommand) : showHelp();
+                return true;
+            } else {
+                std ::cout << "Comando não reconhecido: " << firstCommand
+                           << std::endl;
+                return false;
             }
-
-            showHelp("playlist");
-            return true;
-        }
-        else if (firstCommand == "update_users")
-        {
-            updateUsers();
-            return true;
-        }
-        else if (firstCommand == "update_songs" || firstCommand == "update_library")
-        {
-            updateSongs();
-            return true;
-        }
-        else if (firstCommand == "search")
-        {
-            std::string searchType;
-            if (ss >> searchType)
-            {
-                std::string query;
-                std::getline(ss, query);
-                query.erase(0, query.find_first_not_of(" "));
-
-                if (searchType == "music" || searchType == "song")
-                {
-                    searchSong(query);
-                    return true;
-                }
-                else if (searchType == "artist")
-                {
-                    searchArtist(query);
-                    return true;
-                }
-                else if (searchType == "album")
-                {
-                    searchAlbum(query);
-                    return true;
-                }
-                else if (searchType == "playlist")
-                {
-                    searchPlaylist(query);
-                    return true;
-                }
-                else
-                {
-                    std::cout << "Tipo de busca inválido. Use 'music', 'artist', 'album' ou 'playlist'." << std::endl;
-                    return false;
-                }
-            }
-
-            showHelp("search");
-            return true;
-        }
-        else if (firstCommand == "help")
-        {
-            ss >> firstCommand ? showHelp(firstCommand) : showHelp();
-            return true;
-        }
-        else
-        {
-            std ::cout << "Comando não reconhecido: " << firstCommand << std::endl;
-            return false;
-        }
-        } catch (const std::exception &e) {
-            std::cerr << "Erro ao executar o comando '" << command << "': " << e.what() << std::endl;
+        } catch (const std::exception& e) {
+            std::cerr << "Erro ao executar o comando '" << command
+                      << "': " << e.what() << std::endl;
             return false;
         }
     }
-}
+} // namespace cli

--- a/src/core/services/Player.cpp
+++ b/src/core/services/Player.cpp
@@ -5,8 +5,23 @@
 #include <iostream>
 #include <memory>
 #include <stdexcept>
+#include <atomic>
+#include <thread>
+#include <chrono>
 
 namespace core {
+
+    void Player::onSoundEnd(void* pUserData, ma_sound* pSound) {
+        Player* player = static_cast<Player*>(pUserData);
+        if (player && !player->_isLooping) {
+            player->_shouldAdvanceToNext.store(true, std::memory_order_release);
+
+            std::thread([player]() {
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                player->checkAndAdvanceIfNeeded();
+            }).detach();
+        }
+    }
 
     Player::Player()
         : _currentQueueIndex(-1),
@@ -16,13 +31,13 @@ namespace core {
           _volume(1.0f),
           _previousVolume(1.0f),
           _audioInitialized(false),
-          _inCallback(false),
+          _shouldAdvanceToNext(false),
           _songStartTime(0),
           _hasSongStartTime(false) {
-
         ma_result result = ma_engine_init(NULL, &_audioEngine);
         if (result != MA_SUCCESS) {
-            throw std::runtime_error("Falha ao inicializar Audio Engine: " + std::to_string(result));
+            throw std::runtime_error("Falha ao inicializar Audio Engine: "
+                                     + std::to_string(result));
         }
 
         _audioInitialized = true;
@@ -33,7 +48,8 @@ namespace core {
         _queue = std::make_shared<core::PlaybackQueue>();
     }
 
-    Player::Player(const core::PlaybackQueue &tracks) : Player() {
+    Player::Player(const core::PlaybackQueue& tracks)
+        : Player() {
         addPlaybackQueue(tracks);
     }
 
@@ -45,7 +61,8 @@ namespace core {
     }
 
     std::shared_ptr<PlaybackQueue> Player::getCurrentQueue() const {
-        if (_currentQueueIndex >= 0 && static_cast<size_t>(_currentQueueIndex) < _queues.size()) {
+        if (_currentQueueIndex >= 0
+            && static_cast<size_t>(_currentQueueIndex) < _queues.size()) {
             return _queues[_currentQueueIndex];
         }
         return nullptr;
@@ -67,6 +84,8 @@ namespace core {
             ma_sound_stop(&_currentSound);
         }
 
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
         ma_sound_uninit(&_currentSound);
         memset(&_currentSound, 0, sizeof(_currentSound));
 
@@ -78,21 +97,20 @@ namespace core {
             throw std::runtime_error("Audio engine não inicializado");
         }
 
-        // auto currentQueue = getCurrentQueue();
         if (!_queue) {
             throw std::runtime_error("Queue inválida");
         }
 
-        if (_currentSongIndex < 0 || static_cast<size_t>(_currentSongIndex) >= _queue->size()) {
+        if (_currentSongIndex < 0
+            || static_cast<size_t>(_currentSongIndex) >= _queue->size()) {
             throw std::runtime_error("Índice inválido");
         }
 
-        // Limpa som anterior
         cleanupCurrentSound();
 
         _currentSong = _queue->getCurrentSong();
         if (!_currentSong) {
-            throw std::runtime_error("Música é null");
+            throw std::runtime_error("Música nula");
         }
 
         std::string filePath = _currentSong->getAudioFilePath();
@@ -100,21 +118,17 @@ namespace core {
             throw std::runtime_error("Caminho vazio");
         }
 
-        // Inicializa com flags de decodificação
         ma_uint32 flags = MA_SOUND_FLAG_DECODE | MA_SOUND_FLAG_ASYNC;
 
         ma_result result = ma_sound_init_from_file(
-            &_audioEngine,
-            filePath.c_str(),
-            flags,
-            NULL,
-            NULL,
-            &_currentSound);
+            &_audioEngine, filePath.c_str(), flags, NULL, NULL, &_currentSound);
 
         if (result != MA_SUCCESS) {
             std::cerr << "Erro ao carregar: " << result << std::endl;
             return false;
         }
+
+        ma_sound_set_end_callback(&_currentSound, onSoundEnd, this);
 
         ma_sound_set_volume(&_currentSound, _volume);
         ma_sound_set_looping(&_currentSound, _isLooping ? MA_TRUE : MA_FALSE);
@@ -126,20 +140,19 @@ namespace core {
         return true;
     }
 
-    void Player::addPlaybackQueue(const core::PlaybackQueue &tracks) {
+    void Player::addPlaybackQueue(const core::PlaybackQueue& tracks) {
         if (tracks.empty()) {
             throw std::invalid_argument("PlaybackQueue nao pode ser vazia");
         }
 
         *_queue += tracks;
-        // _queues.push_back(std::make_shared<core::PlaybackQueue>(tracks));
+    }
 
-        // if (_currentQueueIndex == -1 && !_queues.empty()) {
-        //     _currentQueueIndex = 0;
-        //     if (_queues[0]->size() > 0) {
-        //         _currentSongIndex = 0;
-        //     }
-        // }
+    void Player::checkAndAdvanceIfNeeded() {
+        if (_shouldAdvanceToNext.load(std::memory_order_acquire)) {
+            _shouldAdvanceToNext.store(false, std::memory_order_release);
+            playNextSong();
+        }
     }
 
     void Player::play() {
@@ -156,7 +169,6 @@ namespace core {
             _currentQueueIndex = 0;
         }
 
-        // auto currentQueue = getCurrentQueue();
         if (!_queue || _queue->empty()) {
             return;
         }
@@ -169,20 +181,21 @@ namespace core {
             ma_result result = ma_sound_start(&_currentSound);
             if (result == MA_SUCCESS) {
                 _playerState = PlayerState::PLAYING;
-                std::cout << " Reproduzindo..." << std::endl;
             }
         }
     }
 
     void Player::pause() {
-        if (_playerState == PlayerState::PLAYING && ma_sound_is_playing(&_currentSound)) {
+        if (_playerState == PlayerState::PLAYING
+            && ma_sound_is_playing(&_currentSound)) {
             ma_sound_stop(&_currentSound);
             _playerState = PlayerState::PAUSED;
         }
     }
 
     void Player::resume() {
-        if (_playerState == PlayerState::PAUSED && _currentSound.pDataSource != nullptr) {
+        if (_playerState == PlayerState::PAUSED
+            && _currentSound.pDataSource != nullptr) {
             ma_sound_start(&_currentSound);
             _playerState = PlayerState::PLAYING;
         }
@@ -202,13 +215,10 @@ namespace core {
     }
 
     void Player::playNextSong() {
-        // auto currentQueue = getCurrentQueue();
         if (!_queue || _queue->empty()) {
             _playerState = PlayerState::STOPPED;
             return;
         }
-
-        // int nextIndex = _currentSongIndex + 1;
 
         auto nextSong = _queue->next();
 
@@ -218,36 +228,12 @@ namespace core {
             return;
         }
 
-        // if (static_cast<size_t>(nextIndex) >= _queue->size()) {
-        //     if (_isLooping) {
-        //         _currentSongIndex = 0;
-        //     } else {
-        //         int nextQueueIndex = _currentQueueIndex + 1;
-
-        //         if (static_cast<size_t>(nextQueueIndex) < _queues.size()) {
-        //             auto nextQueue = _queues[nextQueueIndex];
-        //             if (nextQueue && !nextQueue->empty()) {
-        //                 _currentQueueIndex = nextQueueIndex;
-        //                 _currentSongIndex = 0;
-        //             } else {
-        //                 _playerState = PlayerState::STOPPED;
-        //                 cleanupCurrentSound();
-        //                 return;
-        //             }
-        //         } else {
-        //             _playerState = PlayerState::STOPPED;
-        //             cleanupCurrentSound();
-        //             return;
-        //         }
-        //     }
-        // } else {
-        //     _currentSongIndex = nextIndex;
-        // }
-
         if (loadCurrentSong()) {
             ma_result result = ma_sound_start(&_currentSound);
             if (result == MA_SUCCESS) {
                 _playerState = PlayerState::PLAYING;
+            } else {
+                std::cerr << "Erro ao iniciar som: " << result << std::endl;
             }
         }
     }
@@ -257,33 +243,14 @@ namespace core {
     }
 
     void Player::previous() {
-        // auto currentQueue = getCurrentQueue();
         if (!_queue || _queue->empty()) {
             throw std::runtime_error("Queue não inicializada");
         }
-
-        // int prevIndex = _currentSongIndex - 1;
 
         auto prevSong = _queue->previous();
 
         if (!prevSong)
             return;
-
-        // if (prevIndex < 0) {
-        //     if (_isLooping) {
-        //         prevIndex = currentQueue->size() - 1;
-        //     } else {
-        //         int prevQueueIndex = _currentQueueIndex - 1;
-        //         if (prevQueueIndex >= 0 && !_queues[prevQueueIndex]->empty()) {
-        //             _currentQueueIndex = prevQueueIndex;
-        //             _currentSongIndex = _queues[prevQueueIndex]->size() - 1;
-        //         } else {
-        //             return;
-        //         }
-        //     }
-        // } else {
-        //     _currentSongIndex = prevIndex;
-        // }
 
         if (loadCurrentSong()) {
             ma_sound_start(&_currentSound);
@@ -300,7 +267,8 @@ namespace core {
         ma_sound_get_cursor_in_pcm_frames(&_currentSound, &currentFrame);
 
         ma_uint64 sampleRate = ma_engine_get_sample_rate(&_audioEngine);
-        ma_int64 framesToSeek = static_cast<ma_int64>(seconds) * static_cast<ma_int64>(sampleRate);
+        ma_int64 framesToSeek =
+            static_cast<ma_int64>(seconds) * static_cast<ma_int64>(sampleRate);
         ma_uint64 newFrame;
 
         if (framesToSeek < 0) {
@@ -367,36 +335,20 @@ namespace core {
     }
 
     PlayerState Player::stateOfPlayer() const {
-        if (_playerState == PlayerState::PLAYING && _currentSound.pDataSource != nullptr) {
-            bool soundIsPlaying = ma_sound_is_playing(&_currentSound);
-
-            // Se o estado diz PLAYING mas o som parou = música terminou!
-            if (!soundIsPlaying && !_isLooping) {
-                const_cast<Player *>(this)->playNextSong();
-            }
-        }
-
+        const_cast<Player*>(this)->checkAndAdvanceIfNeeded();
         return _playerState;
     }
 
-    bool Player::isMuted() const
-    {
+    bool Player::isMuted() const {
         return _volume == 0.0f;
     }
 
     bool Player::isPlaying() const {
-        if (_playerState == PlayerState::PLAYING && _currentSound.pDataSource != nullptr) {
-            bool soundIsPlaying = ma_sound_is_playing(&_currentSound);
+        const_cast<Player*>(this)->checkAndAdvanceIfNeeded();
 
-            // Se o estado diz PLAYING mas o som não está tocando, a música terminou
-            if (!soundIsPlaying && !_isLooping) {
-                const_cast<Player *>(this)->playNextSong();
-                return _playerState == PlayerState::PLAYING;
-            }
-
-            return soundIsPlaying;
-        }
-        return false;
+        return _playerState == PlayerState::PLAYING
+               && _currentSound.pDataSource != nullptr
+               && ma_sound_is_playing(&_currentSound);
     }
 
     bool Player::isPaused() const {
@@ -404,24 +356,33 @@ namespace core {
     }
 
     unsigned int Player::getElapsedTime() const {
-        if (!_currentSong || _currentSound.pDataSource == nullptr || !_hasSongStartTime) {
+        const_cast<Player*>(this)->checkAndAdvanceIfNeeded();
+
+        if (!_currentSong || _currentSound.pDataSource == nullptr
+            || !_hasSongStartTime) {
             return 0;
         }
 
         ma_uint64 currentTime = getEngineTime();
-        ma_uint64 elapsed = (currentTime >= _songStartTime) ? (currentTime - _songStartTime) : 0;
+        ma_uint64 elapsed = (currentTime >= _songStartTime)
+                                ? (currentTime - _songStartTime)
+                                : 0;
         ma_uint64 sampleRate = ma_engine_get_sample_rate(&_audioEngine);
 
         return static_cast<unsigned int>(elapsed / sampleRate);
     }
 
     float Player::getProgress() const {
+        // Verifica se deve avançar
+        const_cast<Player*>(this)->checkAndAdvanceIfNeeded();
+
         if (!_currentSong || _currentSound.pDataSource == nullptr) {
             return 0.0f;
         }
 
         ma_uint64 lengthInFrames;
-        ma_result lengthResult = ma_sound_get_length_in_pcm_frames(&_currentSound, &lengthInFrames);
+        ma_result lengthResult =
+            ma_sound_get_length_in_pcm_frames(&_currentSound, &lengthInFrames);
 
         if (lengthResult != MA_SUCCESS || lengthInFrames == 0) {
             return 0.0f;
@@ -431,11 +392,12 @@ namespace core {
         ma_uint64 sampleRate = ma_engine_get_sample_rate(&_audioEngine);
         ma_uint64 elapsedFrames = elapsed * sampleRate;
 
-        return std::min(1.0f, static_cast<float>(elapsedFrames) / static_cast<float>(lengthInFrames));
+        return std::min(1.0f,
+                        static_cast<float>(elapsedFrames)
+                            / static_cast<float>(lengthInFrames));
     }
 
     int Player::getPlaylistSize() const {
-        // auto currentQueue = getCurrentQueue();
         if (!_queue) {
             throw std::runtime_error("Queue não inicializada");
         }
@@ -458,24 +420,10 @@ namespace core {
 
     bool Player::hasNext() const {
         return _queue->getNextSong() != nullptr;
-
-        // auto currentQueue = getCurrentQueue();
-        // if (!currentQueue) {
-        //     return false;
-        // }
-
-        // return (static_cast<size_t>(_currentSongIndex) + 1 < currentQueue->size()) ||
-        //        (static_cast<size_t>(_currentQueueIndex) + 1 < _queue.size());
     }
 
     bool Player::hasPrevious() const {
         return _queue->getPreviousSong() != nullptr;
-        // auto currentQueue = getCurrentQueue();
-        // if (!currentQueue) {
-        //     return false;
-        // }
-
-        // return (_currentSongIndex > 0) || (_currentQueueIndex > 0);
     }
 
 } // namespace core


### PR DESCRIPTION
# Implementação de transição automática de músicas com callbacks

## Alterações realizadas

### 1. Substituição de polling por event-driven callback

**Antes:**
- Os métodos `stateOfPlayer()` e `isPlaying()` verificavam constantemente se a música havia terminado
- Uso de `const_cast` para modificar estado em métodos const
- Verificações desnecessárias a cada chamada (aproximadamente 60x por segundo se a UI roda a 60 FPS)
- Alta latência na detecção do fim da música

**Depois:**
- Utilização do callback `ma_sound_set_end_callback()` do miniaudio
- Detecção instantânea do término da música
- Eliminação de polling e verificações redundantes
- Redução significativa do uso de CPU

### 2. Prevenção de deadlock com execução assíncrona

**Problema identificado:**
Chamar `ma_sound_uninit()` diretamente no callback de término causava deadlock, pois o callback é executado na thread de áudio do miniaudio e `uninit()` tenta aguardar essa mesma thread finalizar.

**Solução implementada:**
- Callback marca apenas uma flag atômica `_shouldAdvanceToNext`
- Thread separada e detached aguarda 50ms antes de executar a transição
- Delay garante que o callback retornou e o miniaudio finalizou seu processamento interno
- Execução de `ma_sound_uninit()` acontece em contexto seguro, fora do callback

### 3. Novos membros e métodos

**Adicionados:**
- `std::atomic<bool> _shouldAdvanceToNext`: flag thread-safe para comunicação entre threads
- `static void onSoundEnd(void* pUserData, ma_sound* pSound)`: callback registrado no miniaudio
- `void checkAndAdvanceIfNeeded()`: verifica flag e executa transição quando necessário


